### PR TITLE
Feat/container pause unpause

### DIFF
--- a/docker/containers.go
+++ b/docker/containers.go
@@ -75,3 +75,7 @@ func (d *docker) ContainerRemove(containerID string, removeForm *entities.Contai
 func (d *docker) ContainerRename(containerID, newName string) error {
 	return d.cli.ContainerRename(context.TODO(), containerID, newName)
 }
+
+func (d *docker) ContainerPause(containerID string) error {
+	return d.cli.ContainerPause(context.TODO(), containerID)
+}

--- a/docker/containers.go
+++ b/docker/containers.go
@@ -79,3 +79,7 @@ func (d *docker) ContainerRename(containerID, newName string) error {
 func (d *docker) ContainerPause(containerID string) error {
 	return d.cli.ContainerPause(context.TODO(), containerID)
 }
+
+func (d *docker) ContainerUnpause(containerID string) error {
+	return d.cli.ContainerUnpause(context.TODO(), containerID)
+}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -19,6 +19,8 @@ type Docker interface {
 	ContainerStop(containerID string) error
 	ContainerRemove(containerID string, removeForm *entities.ContainerRemoveForm) error
 	ContainerRename(containerID, newName string) error
+	ContainerPause(containerID string) error
+
 
 	ImagesList() []*entities.Image
 	ImageTag(ctx context.Context, imageID, newTag string) error

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -20,7 +20,7 @@ type Docker interface {
 	ContainerRemove(containerID string, removeForm *entities.ContainerRemoveForm) error
 	ContainerRename(containerID, newName string) error
 	ContainerPause(containerID string) error
-
+    ContainerUnpause(containerID string) error
 
 	ImagesList() []*entities.Image
 	ImageTag(ctx context.Context, imageID, newTag string) error

--- a/telegram/btns/btns.go
+++ b/telegram/btns/btns.go
@@ -27,6 +27,7 @@ const (
 	ContRemoveForce  BtnKey = "contFcRm"
 	ContRemoveVolume BtnKey = "contRmVol"
 	ContRemoveDone   BtnKey = "contRmDone"
+	ContPause        BtnKey = "contPause"
 
 	// Images
 	Images     BtnKey = "imgs"

--- a/telegram/btns/btns.go
+++ b/telegram/btns/btns.go
@@ -28,6 +28,7 @@ const (
 	ContRemoveVolume BtnKey = "contRmVol"
 	ContRemoveDone   BtnKey = "contRmDone"
 	ContPause        BtnKey = "contPause"
+	ContUnpause      BtnKey = "contUnpause"
 
 	// Images
 	Images     BtnKey = "imgs"

--- a/telegram/handlers/containers.go
+++ b/telegram/handlers/containers.go
@@ -121,3 +121,18 @@ func (h *handler) ContainerStop(ctx telebot.Context) error {
 		telebot.ModeMarkdownV2,
 	)
 }
+
+func (h *handler) ContainerPause(ctx telebot.Context) error {
+	userID := ctx.Chat().ID
+	index, err := strconv.Atoi(ctx.Data())
+	session := h.session.Get(userID)
+	if err != nil {
+		log.Gl.Error(err.Error())
+	}
+	current := session.GetContainer(index)
+	if err := h.docker.ContainerPause(current.ID); err != nil {
+		log.Gl.Error(err.Error())
+		return ctx.Respond(msgs.CannotPauseContainer)
+	}
+	return ctx.Respond(msgs.ContainerPausedSuccessfully)
+}

--- a/telegram/handlers/containers.go
+++ b/telegram/handlers/containers.go
@@ -136,3 +136,18 @@ func (h *handler) ContainerPause(ctx telebot.Context) error {
 	}
 	return ctx.Respond(msgs.ContainerPausedSuccessfully)
 }
+
+func (h *handler) ContainerUnpause(ctx telebot.Context) error {
+	userID := ctx.Chat().ID
+	index, err := strconv.Atoi(ctx.Data())
+	session := h.session.Get(userID)
+	if err != nil {
+		log.Gl.Error(err.Error())
+	}
+	current := session.GetContainer(index)
+	if err := h.docker.ContainerUnpause(current.ID); err != nil {
+		log.Gl.Error(err.Error())
+		return ctx.Respond(msgs.CannotUnpauseContainer)
+	}
+	return ctx.Respond(msgs.ContainerUnpausedSuccessfully)
+}

--- a/telegram/handlers/handlers.go
+++ b/telegram/handlers/handlers.go
@@ -56,6 +56,7 @@ func NewHandler(bot *telebot.Bot, docker docker.Docker, session sessionPkg.Sessi
 	h.bot.Handle(btns.ImgRmDone.Key(), h.ImageRemoveDone)
 	h.bot.Handle(btns.ImgTag.Key(), h.ImageTag)
 	h.bot.Handle(btns.ContPause.Key(), h.ContainerPause)
+	h.bot.Handle(btns.ContUnpause.Key(), h.ContainerUnpause)
 	
 	return h
 }

--- a/telegram/handlers/handlers.go
+++ b/telegram/handlers/handlers.go
@@ -55,6 +55,7 @@ func NewHandler(bot *telebot.Bot, docker docker.Docker, session sessionPkg.Sessi
 	h.bot.Handle(btns.ImgRmPruneCh.Key(), h.ImageRemovePruneChildren)
 	h.bot.Handle(btns.ImgRmDone.Key(), h.ImageRemoveDone)
 	h.bot.Handle(btns.ImgTag.Key(), h.ImageTag)
-
+	h.bot.Handle(btns.ContPause.Key(), h.ContainerPause)
+	
 	return h
 }

--- a/telegram/keyboards/containers.go
+++ b/telegram/keyboards/containers.go
@@ -17,6 +17,7 @@ func ContainersList(index int, containerIsOn bool) *telebot.ReplyMarkup {
 		},
 		telebot.Row{
 			switchBtn(keyboard, index, containerIsOn),
+			keyboard.Data("Pause ⏸", btns.ContPause.String(), fmt.Sprint(index)),
 			keyboard.Data("Remove 🗑", btns.ContRemoveForm.String(), fmt.Sprint(index)),
 			keyboard.Data("Rename ✏️", btns.ContRename.String(), fmt.Sprint(index)),
 		},
@@ -25,7 +26,6 @@ func ContainersList(index int, containerIsOn bool) *telebot.ReplyMarkup {
 			keyboard.Data("Stats 📊", btns.ContStats.String(), fmt.Sprint(index)),
 		},
 	)
-
 	return keyboard
 }
 

--- a/telegram/keyboards/containers.go
+++ b/telegram/keyboards/containers.go
@@ -18,6 +18,7 @@ func ContainersList(index int, containerIsOn bool) *telebot.ReplyMarkup {
 		telebot.Row{
 			switchBtn(keyboard, index, containerIsOn),
 			keyboard.Data("Pause ⏸", btns.ContPause.String(), fmt.Sprint(index)),
+			keyboard.Data("Unpause ▶️", btns.ContUnpause.String(), fmt.Sprint(index)),
 			keyboard.Data("Remove 🗑", btns.ContRemoveForm.String(), fmt.Sprint(index)),
 			keyboard.Data("Rename ✏️", btns.ContRename.String(), fmt.Sprint(index)),
 		},

--- a/telegram/msgs/callback_responses.go
+++ b/telegram/msgs/callback_responses.go
@@ -16,6 +16,8 @@ var (
 	StoppedButUnavailableCurrentState = NewCallbackResponse("Container stopped, but we're not able to show current state.")
 	CannotPauseContainer              = NewCallbackResponse("We cannot pause the container!")
 	ContainerPausedSuccessfully       = NewCallbackResponse("Container paused successfully")
+	CannotUnpauseContainer            = NewCallbackResponse("We cannot unpause the container!")
+	ContainerUnpausedSuccessfully     = NewCallbackResponse("Container unpaused successfully")
 )
 
 func NewCallbackResponse(text string) *telebot.CallbackResponse {

--- a/telegram/msgs/callback_responses.go
+++ b/telegram/msgs/callback_responses.go
@@ -14,6 +14,8 @@ var (
 	NoContainer                       = NewCallbackResponse("There is either no containers or you should run /containers again!")
 	StartedButUnavailableCurrentState = NewCallbackResponse("Container started, but we're not able to show current state.")
 	StoppedButUnavailableCurrentState = NewCallbackResponse("Container stopped, but we're not able to show current state.")
+	CannotPauseContainer              = NewCallbackResponse("We cannot pause the container!")
+	ContainerPausedSuccessfully       = NewCallbackResponse("Container paused successfully")
 )
 
 func NewCallbackResponse(text string) *telebot.CallbackResponse {


### PR DESCRIPTION
Hi Arsham
This PR adds support for pausing and unpausing docker containers directly from the telegram bot.

Changes:
Added ContainerPause and ContainerUnpause methods to the docker interface and implementation.
Added new inline buttons (pause/unpause) to the container list keyboard.
Implemented handlers, router registrations, and callback responses for both actions.
